### PR TITLE
Map product images from DTO and expose gallery URLs

### DIFF
--- a/backend/src/main/java/com/miapp/reservashotel/dto/ProductResponseDTO.java
+++ b/backend/src/main/java/com/miapp/reservashotel/dto/ProductResponseDTO.java
@@ -16,7 +16,7 @@ public class ProductResponseDTO {
     private Long cityId;
     private String cityName;
     private Set<Long> featureIds;
-    private List<String> imageUrls;
+    private List<String> imageUrls = List.of();
     private Double ratingAverage;
     private Long ratingCount;
 
@@ -38,7 +38,7 @@ public class ProductResponseDTO {
         this.cityId = cityId;
         this.cityName = cityName;
         this.featureIds = featureIds;
-        this.imageUrls = imageUrls;
+        this.imageUrls = imageUrls != null ? List.copyOf(imageUrls) : List.of();
         this.ratingAverage = ratingAverage;
         this.ratingCount = ratingCount;
     }
@@ -73,8 +73,10 @@ public class ProductResponseDTO {
 
     public Set<Long> getFeatureIds() { return featureIds; }
     public void setFeatureIds(Set<Long> featureIds) { this.featureIds = featureIds; }
-    public List<String> getImageUrls() { return imageUrls; }
-    public void setImageUrls(List<String> imageUrls) { this.imageUrls = imageUrls; }
+    public List<String> getImageUrls() { return imageUrls == null ? List.of() : imageUrls; }
+    public void setImageUrls(List<String> imageUrls) {
+        this.imageUrls = imageUrls != null ? List.copyOf(imageUrls) : List.of();
+    }
     public Double getRatingAverage() { return ratingAverage; }
     public void setRatingAverage(Double ratingAverage) { this.ratingAverage = ratingAverage; }
     public Long getRatingCount() { return ratingCount; }


### PR DESCRIPTION
## Summary
- map ProductRequestDTO image fields into Product entities, rebuilding ProductImage records and selecting the primary image
- expose gallery URLs through ProductResponseDTO and ensure the DTO always returns a non-null list

## Testing
- ./mvnw test *(fails: Maven wrapper download blocked in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2f6fa8b48328bb7999b8374a42f7