### PR TITLE
Expose feature summaries on product responses

### DIFF
--- a/backend/src/main/java/com/miapp/reservashotel/dto/FeatureSummaryDTO.java
+++ b/backend/src/main/java/com/miapp/reservashotel/dto/FeatureSummaryDTO.java
@@ -1,0 +1,46 @@
+package com.miapp.reservashotel.dto;
+
+/**
+ * Lightweight DTO exposing the minimum information required to render a feature
+ * alongside a product card/detail: identifier, display name and icon.
+ */
+public class FeatureSummaryDTO {
+
+    private Long id;
+    private String name;
+    private String icon;
+
+    public FeatureSummaryDTO() {
+    }
+
+    public FeatureSummaryDTO(Long id, String name, String icon) {
+        this.id = id;
+        this.name = name;
+        this.icon = icon;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+}
+

--- a/backend/src/main/java/com/miapp/reservashotel/dto/ProductResponseDTO.java
+++ b/backend/src/main/java/com/miapp/reservashotel/dto/ProductResponseDTO.java
@@ -15,6 +15,7 @@ public class ProductResponseDTO {
     private String categoryName;
     private Long cityId;
     private String cityName;
+    private List<FeatureSummaryDTO> features;
     private Set<Long> featureIds;
     private List<String> imageUrls;
     private Double ratingAverage;
@@ -26,7 +27,7 @@ public class ProductResponseDTO {
     public ProductResponseDTO(Long id, String name, String description, String imageUrl, BigDecimal price,
                               Long categoryId, String categoryName,
                               Long cityId, String cityName,
-                              Set<Long> featureIds, List<String> imageUrls,
+                              List<FeatureSummaryDTO> features, Set<Long> featureIds, List<String> imageUrls,
                               Double ratingAverage, Long ratingCount) {
         this.id = id;
         this.name = name;
@@ -37,6 +38,7 @@ public class ProductResponseDTO {
         this.categoryName = categoryName;
         this.cityId = cityId;
         this.cityName = cityName;
+        this.features = features;
         this.featureIds = featureIds;
         this.imageUrls = imageUrls;
         this.ratingAverage = ratingAverage;
@@ -70,6 +72,9 @@ public class ProductResponseDTO {
 
     public String getCityName() { return cityName; }
     public void setCityName(String cityName) { this.cityName = cityName; }
+
+    public List<FeatureSummaryDTO> getFeatures() { return features; }
+    public void setFeatures(List<FeatureSummaryDTO> features) { this.features = features; }
 
     public Set<Long> getFeatureIds() { return featureIds; }
     public void setFeatureIds(Set<Long> featureIds) { this.featureIds = featureIds; }

--- a/backend/src/main/java/com/miapp/reservashotel/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/miapp/reservashotel/service/impl/ProductServiceImpl.java
@@ -1,5 +1,6 @@
 package com.miapp.reservashotel.service.impl;
 
+import com.miapp.reservashotel.dto.FeatureSummaryDTO;
 import com.miapp.reservashotel.dto.ProductRequestDTO;
 import com.miapp.reservashotel.dto.ProductResponseDTO;
 import com.miapp.reservashotel.exception.ResourceConflictException;
@@ -250,8 +251,14 @@ public class ProductServiceImpl implements ProductService {
                 ? Collections.emptySet()
                 : p.getFeatures().stream().map(Feature::getId)
                     .collect(Collectors.toCollection(LinkedHashSet::new));
+        List<FeatureSummaryDTO> featureSummaries = p.getFeatures() == null
+                ? Collections.emptyList()
+                : p.getFeatures().stream()
+                        .map(f -> new FeatureSummaryDTO(f.getId(), f.getName(), f.getIcon()))
+                        .toList();
         try {
             dto.setFeatureIds(featureIds);
+            dto.setFeatures(featureSummaries);
         } catch (Throwable ignored) { /* DTO may not expose setter in some variants */ }
 
         // Ratings are optional on the entity

--- a/backend/src/main/resources/static/openapi.yaml
+++ b/backend/src/main/resources/static/openapi.yaml
@@ -59,10 +59,20 @@ components:
           properties:
             id: { type: integer, format: int64 }
             name: { type: string }
+        features:
+          type: array
+          items: { $ref: '#/components/schemas/FeatureSummaryDTO' }
         featureIds:
           type: array
           items: { type: integer, format: int64 }
         imageUrl: { type: string }
+
+    FeatureSummaryDTO:
+      type: object
+      properties:
+        id: { type: integer, format: int64 }
+        name: { type: string }
+        icon: { type: string }
 
     ProductSearchResponse:
       type: object

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -47,7 +47,12 @@ export default function ProductDetail() {
   const refreshProduct = useCallback(async () => {
     try {
       const data = await getProduct(productId);
-      if (data) setProduct((prev) => ({ ...prev, ...data }));
+      if (data)
+        setProduct((prev) => ({
+          ...prev,
+          ...data,
+          features: Array.isArray(data.features) ? data.features : [],
+        }));
     } catch {
       /* Silent: keep UX minimal */
     }

--- a/frontend/src/pages/admin/ProductCreateAdmin.jsx
+++ b/frontend/src/pages/admin/ProductCreateAdmin.jsx
@@ -3,6 +3,13 @@ import { useNavigate } from "react-router-dom";
 import Api from "../../services/api";
 import { useToast } from "../../shared/ToastProvider.jsx";
 
+const EMOJI_REGEX = /\p{Extended_Pictographic}/u;
+
+function renderFeatureIcon(icon) {
+  if (!icon) return "•";
+  return EMOJI_REGEX.test(icon) ? icon : <i className={icon}></i>;
+}
+
 const MAX_IMAGES = 5;
 
 export default function ProductCreateAdmin() {
@@ -263,12 +270,18 @@ export default function ProductCreateAdmin() {
             {features.map((feature) => {
               const selected = form.featureIds.includes(feature.id);
               return (
-                <label key={feature.id} className="flex items-center gap-2 border rounded px-3 py-2 bg-white">
+                <label
+                  key={feature.id}
+                  className="flex items-center gap-2 border rounded px-3 py-2 bg-white"
+                >
                   <input
                     type="checkbox"
                     checked={selected}
                     onChange={() => toggleFeature(feature.id)}
                   />
+                  <span className="text-lg leading-none">
+                    {renderFeatureIcon(feature.icon)}
+                  </span>
                   <span>{feature.name}</span>
                 </label>
               );

--- a/frontend/src/pages/admin/ProductEditAdmin.jsx
+++ b/frontend/src/pages/admin/ProductEditAdmin.jsx
@@ -5,6 +5,13 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Api from "../../services/api.js";
 
+const EMOJI_REGEX = /\p{Extended_Pictographic}/u;
+
+function renderFeatureIcon(icon) {
+    if (!icon) return "•";
+    return EMOJI_REGEX.test(icon) ? icon : <i className={icon}></i>;
+}
+
 /** Validates only what is necessary to prevent obvious errors. */
 function isValid(form) {
     return (
@@ -214,7 +221,7 @@ function isValid(form) {
                     <button
                         key={f.id}
                         type="button"
-                        className={`px-3 py-1 rounded-lg border text-sm ${
+                        className={`px-3 py-1 rounded-lg border text-sm flex items-center gap-2 ${
                         active ? "bg-emerald-600 text-white border-emerald-600" : "hover:bg-slate-50"
                         }`}
                         onClick={() => {
@@ -226,7 +233,10 @@ function isValid(form) {
                         }}
                         title={f.name}
                     >
-                        {f.name}
+                        <span className="text-lg leading-none">
+                            {renderFeatureIcon(f.icon)}
+                        </span>
+                        <span>{f.name}</span>
                     </button>
                     );
                 })}


### PR DESCRIPTION
## Summary
- add a lightweight `FeatureSummaryDTO` and expose it from `ProductResponseDTO`
- map product features to summaries in the service layer and document the new field in OpenAPI
- ensure the product detail view and admin forms consume the icon + name metadata when rendering features

## Testing
- ./mvnw -q test *(fails: wget cannot download Maven distribution in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce30eb12dc832899759026b4f2250c