### PR TITLE
feat: enable product reviews with comments

### DIFF
--- a/frontend/src/components/RatingStars.jsx
+++ b/frontend/src/components/RatingStars.jsx
@@ -16,6 +16,8 @@ export default function RatingStars({ productId, className = "", initialAverage 
   const toast = useToast();
   const [average, setAverage] = useState(Number(initialAverage) || 0);
   const [hover, setHover] = useState(0);
+  const [selected, setSelected] = useState(0);
+  const [comment, setComment] = useState("");
   const [busy, setBusy] = useState(false);
   const isLogged = !!getToken();
 
@@ -24,6 +26,7 @@ export default function RatingStars({ productId, className = "", initialAverage 
   }, [initialAverage]);
 
   useEffect(() => {
+    if (!productId) return;
     let mounted = true;
     (async () => {
       try {
@@ -42,25 +45,47 @@ export default function RatingStars({ productId, className = "", initialAverage 
 
   async function refreshAverage() {
     try {
+      if (!productId) return average;
       const data = await Api.getProductRating(productId);
-      setAverage(Number(data?.rating ?? 0));
+      const newAverage = Number(data?.rating ?? 0);
+      setAverage(newAverage);
+      return newAverage;
     } catch (error) {
       console.warn("Failed to refresh rating average", error);
+      return average;
     }
   }
 
-  async function rate(stars) {
+  function handleSelect(stars) {
     if (!isLogged) {
       toast?.info(formatMessage({ id: "rating.loginRequired", defaultMessage: "Inicia sesión para puntuar." }));
       return;
     }
 
+    setSelected(stars);
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    if (!isLogged) {
+      toast?.info(formatMessage({ id: "rating.loginRequired", defaultMessage: "Inicia sesión para puntuar." }));
+      return;
+    }
+
+    if (!selected) {
+      toast?.error(formatMessage({ id: "rating.selectScore", defaultMessage: "Selecciona una puntuación." }));
+      return;
+    }
+
     setBusy(true);
     try {
-      await Api.rateProduct(productId, stars);
+      await Api.rateProduct(productId, selected, comment.trim() || null);
       toast?.success(formatMessage({ id: "rating.success", defaultMessage: "¡Gracias por tu valoración!" }));
-      await refreshAverage();
-      onRated?.(stars);
+      const updatedAverage = await refreshAverage();
+      onRated?.({ score: selected, comment, average: updatedAverage });
+      setComment("");
+      setSelected(0);
     } catch (error) {
       const normalized = normalizeApiError(error, formatMessage({ id: "errors.generic" }));
       const message = getApiErrorMessage(normalized, formatMessage, formatMessage({ id: "errors.generic" }));
@@ -71,26 +96,60 @@ export default function RatingStars({ productId, className = "", initialAverage 
   }
 
   return (
-    <div className={`flex items-center gap-1 ${className}`} aria-label={formatMessage({ id: "rating.averageLabel", defaultMessage: "Calificación promedio" })}>
-      {[1, 2, 3, 4, 5].map((n) => {
-        const filled = (hover || average) >= n;
-        return (
-          <button
-            key={n}
-            className="text-2xl leading-none"
-            disabled={busy}
-            onMouseEnter={() => setHover(n)}
-            onMouseLeave={() => setHover(0)}
-            onClick={() => rate(n)}
-            aria-label={formatMessage({ id: "rating.rateStar", defaultMessage: "Puntuar" }) + ` ${n}`}
-            title={formatMessage({ id: "rating.rateStar", defaultMessage: "Puntuar" }) + ` ${n}`}
-            type="button"
-          >
-            {filled ? "★" : "☆"}
-          </button>
-        );
-      })}
-      <span className="ml-2 text-sm text-gray-600">({average.toFixed(1)}/5)</span>
-    </div>
+    <form className={`space-y-3 ${className}`} onSubmit={handleSubmit}>
+      <div
+        className="flex items-center gap-1"
+        aria-label={formatMessage({ id: "rating.averageLabel", defaultMessage: "Calificación promedio" })}
+      >
+        {[1, 2, 3, 4, 5].map((n) => {
+          const filled = (hover || selected || average) >= n && (hover ? hover >= n : selected ? selected >= n : average >= n);
+          return (
+            <button
+              key={n}
+              className="text-2xl leading-none"
+              disabled={busy}
+              onMouseEnter={() => setHover(n)}
+              onMouseLeave={() => setHover(0)}
+              onClick={() => handleSelect(n)}
+              aria-label={formatMessage({ id: "rating.rateStar", defaultMessage: "Puntuar" }) + ` ${n}`}
+              title={formatMessage({ id: "rating.rateStar", defaultMessage: "Puntuar" }) + ` ${n}`}
+              type="button"
+            >
+              {filled ? "★" : "☆"}
+            </button>
+          );
+        })}
+        <span className="ml-2 text-sm text-gray-600">({average.toFixed(1)}/5)</span>
+      </div>
+      <label className="block text-sm text-slate-700">
+        <span className="mb-1 block font-medium">
+          {formatMessage({ id: "rating.commentLabel", defaultMessage: "Tu reseña" })}
+        </span>
+        <textarea
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          disabled={busy || !isLogged}
+          placeholder={formatMessage({ id: "rating.commentPlaceholder", defaultMessage: "Comparte tu experiencia..." })}
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-emerald-500"
+          rows={3}
+        />
+      </label>
+      <div className="flex items-center justify-end">
+        <button
+          type="submit"
+          disabled={busy || !isLogged}
+          className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+        >
+          {busy
+            ? formatMessage({ id: "rating.sending", defaultMessage: "Enviando..." })
+            : formatMessage({ id: "rating.submit", defaultMessage: "Enviar reseña" })}
+        </button>
+      </div>
+      {!isLogged && (
+        <p className="text-xs text-slate-500">
+          {formatMessage({ id: "rating.loginPrompt", defaultMessage: "Inicia sesión para dejar una reseña." })}
+        </p>
+      )}
+    </form>
   );
 }

--- a/frontend/src/components/ReviewsList.jsx
+++ b/frontend/src/components/ReviewsList.jsx
@@ -1,0 +1,112 @@
+// frontend/src/components/ReviewsList.jsx
+import { useEffect, useMemo, useState } from "react";
+import { RatingsAPI } from "../services/api";
+
+function formatDate(value) {
+  if (!value) return "";
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(+date)) return "";
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(date);
+  } catch (error) {
+    console.warn("Failed to format review date", error);
+    return "";
+  }
+}
+
+function ReviewItem({ review }) {
+  const createdAt = formatDate(review?.createdAt);
+  const score = Number(review?.score || 0);
+  const safeComment = review?.comment?.trim();
+  const userLabel = review?.userName || (review?.userId ? `Usuario #${review.userId}` : "Usuario");
+
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <header className="flex flex-wrap items-center justify-between gap-2 text-sm text-slate-600">
+        <span className="font-semibold text-slate-800">{userLabel}</span>
+        {createdAt && (
+          <time dateTime={review?.createdAt} className="text-xs text-slate-500">
+            {createdAt}
+          </time>
+        )}
+      </header>
+      <div className="mt-2 flex items-center gap-1 text-lg text-amber-500" aria-hidden>
+        {Array.from({ length: 5 }, (_, index) => (index < score ? "★" : "☆"))}
+      </div>
+      <p className="mt-2 whitespace-pre-line text-sm text-slate-700">
+        {safeComment || "Sin comentarios."}
+      </p>
+    </article>
+  );
+}
+
+export default function ReviewsList({ productId, refreshToken = 0, onStatsChange }) {
+  const [reviews, setReviews] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const stats = useMemo(() => {
+    const count = reviews.length;
+    const total = reviews.reduce((sum, item) => sum + Number(item?.score || 0), 0);
+    const average = count > 0 ? total / count : 0;
+    return { count, average };
+  }, [reviews]);
+
+  useEffect(() => {
+    onStatsChange?.(stats);
+  }, [stats, onStatsChange]);
+
+  useEffect(() => {
+    if (!productId) return;
+
+    let cancelled = false;
+
+    async function fetchReviews() {
+      setLoading(true);
+      setError("");
+      try {
+        const data = await RatingsAPI.listByProduct(productId);
+        if (cancelled) return;
+        setReviews(Array.isArray(data) ? data : []);
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Failed to load product reviews", err);
+        setError("No se pudieron cargar las reseñas. Inténtalo nuevamente.");
+        setReviews([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchReviews();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [productId, refreshToken]);
+
+  if (loading) {
+    return <p className="text-sm text-slate-600">Cargando reseñas…</p>;
+  }
+
+  if (error) {
+    return <p className="text-sm text-red-600">{error}</p>;
+  }
+
+  if (reviews.length === 0) {
+    return <p className="text-sm text-slate-600">Aún no hay reseñas para este producto.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {reviews.map((review) => (
+        <ReviewItem key={review.id ?? `${review.userId}-${review.createdAt}`} review={review} />
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a ReviewsList component that loads product ratings and formats author, date, stars, and comments
- extend RatingStars to collect an optional review comment, submit it with the score, and reset after a successful post
- integrate both components in ProductDetail so rating averages, counts, and review listings refresh immediately after submissions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce31a461b483289a74eca690c317c2