### PR TITLE
Add auth guard for booking route

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import Register from "./pages/Register.jsx";
 import BookingConfirmation from "./pages/BookingConfirmation.jsx";
 import Policies from "./pages/Policies.jsx";
 import Profile from "./pages/Profile.jsx";
+import AuthGuard from "./routes/AuthGuard.jsx";
 
 // Admin
 import AdminLayout from "./pages/admin/AdminLayout.jsx";
@@ -30,7 +31,11 @@ export default function App() {
       <Route element={<Layout />}>
         <Route index element={<Home />} />
         <Route path="/product/:productId" element={<ProductDetail />} />
-        <Route path="/booking/:productId" element={<Booking />} />
+        <Route
+          element={<AuthGuard reason="Necesitas iniciar sesión para completar tu reserva." />}
+        >
+          <Route path="/booking/:productId" element={<Booking />} />
+        </Route>
         <Route path="/booking/confirm" element={<BookingConfirmation />} />
         <Route path="/favorites" element={<Favorites />} />
         <Route path="/bookings" element={<Bookings />} />

--- a/frontend/src/modules/auth/AuthContext.jsx
+++ b/frontend/src/modules/auth/AuthContext.jsx
@@ -24,7 +24,7 @@ export function AuthProvider({ children }) {
     }
   }
 
-  async function login(email, password) {
+  async function login({ email, password }) {
     // Set token BEFORE calling /me to avoid 401 on the first attempt.
     const data = await AuthAPI.login({ email, password });
     if (!data?.token) throw new Error("Missing token");

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../modules/auth/AuthContext';
 import { useToast } from '../shared/ToastProvider.jsx';
 
@@ -7,9 +7,13 @@ export default function Login() {
   const { login, isLoadingAuth } = useAuth();
   const toast = useToast();
   const navigate = useNavigate();
+  const location = useLocation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
+
+  const reason = location.state?.reason;
+  const redirectTo = location.state?.from || '/';
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -17,7 +21,7 @@ export default function Login() {
       setSubmitting(true);
       await login({ email: email.trim(), password });
       toast?.success('Signed in successfully');
-      navigate('/');
+      navigate(redirectTo, { replace: true });
     } catch (err) {
       const msg = err?.payload?.message || err?.message || 'Login error';
       toast?.error(`Login failed: ${msg}`);
@@ -33,6 +37,11 @@ export default function Login() {
         className="bg-white text-slate-900 p-6 rounded-xl shadow w-full max-w-sm grid gap-4"
       >
         <h1 className="text-xl font-semibold">Login</h1>
+        {reason ? (
+          <p className="text-sm text-amber-700 bg-amber-100 border border-amber-200 rounded-lg px-3 py-2">
+            {reason}
+          </p>
+        ) : null}
         <label className="grid gap-1">
           <span className="text-sm">Email</span>
           <input

--- a/frontend/src/routes/AuthGuard.jsx
+++ b/frontend/src/routes/AuthGuard.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "../modules/auth/AuthContext.jsx";
+
+export default function AuthGuard({ reason = "Debes iniciar sesión para continuar." }) {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return (
+      <Navigate
+        to="/login"
+        replace
+        state={{ reason, from: location.pathname + location.search + location.hash }}
+      />
+    );
+  }
+
+  return <Outlet />;
+}


### PR DESCRIPTION
## Summary
- add an AuthGuard that redirects unauthenticated users to the login page with context
- show contextual access notice on the login screen and return users to their intended page after signing in
- adjust AuthContext login signature to accept the credentials object used across the app

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68ce31f1f2048328b6c8a9c99c3340dc