### PR TITLE
feat: enable Mailpit SMTP in dev profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DB_URL=jdbc:mysql://localhost:3306/reservasdb?useSSL=false&allowPublicKeyRetriev
 JWT_SECRET=please-change-this-64-byte-secret-key-1234567890abcdef
 JWT_EXPIRATION=86400000
 SERVER_PORT=8080
+# --- Mail (local SMTP defaults -> Mailpit) ---
 MAIL_HOST=mailpit
 MAIL_PORT=1025
 MAIL_USERNAME=

--- a/backend/README.md
+++ b/backend/README.md
@@ -56,6 +56,21 @@ jwt.secret=${JWT_SECRET:change-me-in-dev-32bytes-secret-key!!}
 jwt.expiration=${JWT_EXPIRATION:86400000}
 ```
 
+**Local SMTP (Mailpit) — dev profile defaults**
+
+```properties
+spring.mail.host=${MAIL_HOST:localhost}
+spring.mail.port=${MAIL_PORT:1025}
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
+spring.mail.properties.mail.smtp.auth=${MAIL_SMTP_AUTH:false}
+spring.mail.properties.mail.smtp.starttls.enable=${MAIL_SMTP_STARTTLS:false}
+```
+
+1. Start Mailpit locally (`docker compose up mailpit`) — UI available at <http://localhost:8025>.
+2. Export the `MAIL_*` variables above (or edit `../.env`) so the backend points to your Mailpit instance.
+3. Run the backend with `SPRING_PROFILES_ACTIVE=dev` and, optionally, `APP_SEED_QA=true` to preload demo data for quick booking tests.
+
 Export your credentials (or rely on `.env`) before running the app, for example:
 
 ```bash

--- a/backend/src/main/java/com/miapp/reservashotel/config/DevMailConfig.java
+++ b/backend/src/main/java/com/miapp/reservashotel/config/DevMailConfig.java
@@ -1,42 +1,47 @@
 package com.miapp.reservashotel.config;
 
-import java.io.InputStream;
-import jakarta.mail.Session;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
+import java.nio.charset.Charset;
+import java.util.Optional;
+import java.util.Properties;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.mail.MailException;
-import org.springframework.mail.MailParseException;
-import org.springframework.mail.SimpleMailMessage;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 /**
- * Bean de correo para DEV que no envía nada.
- * Por qué: permite que la app arranque sin configurar SMTP.
+ * Bean de correo para DEV apuntando a Mailpit (override vía spring.mail.*).
+ * Permite probar envíos reales en local sin tocar perfiles productivos.
  */
 @Configuration
 @Profile("dev")
 public class DevMailConfig {
 
     @Bean
-    public JavaMailSender javaMailSender() {
-        return new NoOpJavaMailSender();
-    }
+    public JavaMailSender javaMailSender(MailProperties mailProperties) {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
 
-    static class NoOpJavaMailSender implements JavaMailSender {
-        @Override public MimeMessage createMimeMessage() { return new MimeMessage((Session) null); }
-        @Override public MimeMessage createMimeMessage(InputStream contentStream) throws MailException {
-            try { return new MimeMessage(null, contentStream); }
-            catch (MessagingException e) { throw new MailParseException(e); }
+        mailSender.setHost(Optional.ofNullable(mailProperties.getHost()).orElse("localhost"));
+        mailSender.setPort(Optional.ofNullable(mailProperties.getPort()).orElse(1025));
+        mailSender.setUsername(mailProperties.getUsername());
+        mailSender.setPassword(mailProperties.getPassword());
+        if (mailProperties.getProtocol() != null) {
+            mailSender.setProtocol(mailProperties.getProtocol());
         }
-        @Override public void send(SimpleMailMessage simpleMessage) throws MailException { /* no-op */ }
-        @Override public void send(SimpleMailMessage... simpleMessages) throws MailException { /* no-op */ }
-        @Override public void send(MimeMessage mimeMessage) throws MailException { /* no-op */ }
-        @Override public void send(MimeMessage... mimeMessages) throws MailException { /* no-op */ }
-        @Override public void send(MimeMessagePreparator mimeMessagePreparator) throws MailException { /* no-op */ }
-        @Override public void send(MimeMessagePreparator... mimeMessagePreparators) throws MailException { /* no-op */ }
+
+        Charset defaultEncoding = mailProperties.getDefaultEncoding();
+        if (defaultEncoding != null) {
+            mailSender.setDefaultEncoding(defaultEncoding.name());
+        }
+
+        if (!mailProperties.getProperties().isEmpty()) {
+            Properties extraProperties = new Properties();
+            extraProperties.putAll(mailProperties.getProperties());
+            mailSender.setJavaMailProperties(extraProperties);
+        }
+
+        return mailSender;
     }
 }


### PR DESCRIPTION
## Summary
- replace the dev NoOp JavaMailSender with a MailProperties-backed sender so local runs target Mailpit by default
- document the MAIL_* overrides in the backend README and .env example to explain how to enable local SMTP

## Testing
- mvn test *(fails: Maven cannot download dependencies because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce31f713f48328a1dfa958196f18d0