### PR TITLE
Add feature descriptions and validate feature API responses

### DIFF
--- a/frontend/src/api/http.js
+++ b/frontend/src/api/http.js
@@ -41,7 +41,7 @@ export async function httpGet(path, { params, headers } = {}) {
   return payload;
 }
 
-export async function httpPost(path, body, { params, headers } = {}) {
+export async function httpPost(path, body, { params, headers, expectedStatus } = {}) {
   const url = resolveApiUrl(path, params);
   const res = await fetch(url, {
     method: "POST",
@@ -51,10 +51,16 @@ export async function httpPost(path, body, { params, headers } = {}) {
   });
   const payload = await parseResponse(res);
   if (!res.ok) throw toError(res, payload);
+  if (expectedStatus) {
+    const expected = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
+    if (!expected.includes(res.status)) {
+      throw toError(res, payload || { message: `Unexpected status code: ${res.status}` });
+    }
+  }
   return payload;
 }
 
-export async function httpPut(path, body, { params, headers } = {}) {
+export async function httpPut(path, body, { params, headers, expectedStatus } = {}) {
   const url = resolveApiUrl(path, params);
   const res = await fetch(url, {
     method: "PUT",
@@ -64,6 +70,12 @@ export async function httpPut(path, body, { params, headers } = {}) {
   });
   const payload = await parseResponse(res);
   if (!res.ok) throw toError(res, payload);
+  if (expectedStatus) {
+    const expected = Array.isArray(expectedStatus) ? expectedStatus : [expectedStatus];
+    if (!expected.includes(res.status)) {
+      throw toError(res, payload || { message: `Unexpected status code: ${res.status}` });
+    }
+  }
   return payload;
 }
 

--- a/frontend/src/pages/admin/FeaturesAdmin.jsx
+++ b/frontend/src/pages/admin/FeaturesAdmin.jsx
@@ -11,9 +11,16 @@ function Row({ f, onSave, onDelete, busy }) {
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(f.name || '');
   const [icon, setIcon] = useState(f.icon || '');
+  const [description, setDescription] = useState(f.description || '');
+
+  useEffect(() => {
+    setName(f.name || '');
+    setIcon(f.icon || '');
+    setDescription(f.description || '');
+  }, [f]);
 
   const save = async () => {
-    await onSave({ ...f, name, icon });
+    await onSave({ ...f, name, icon, description });
     setEditing(false);
   };
 
@@ -32,6 +39,13 @@ function Row({ f, onSave, onDelete, busy }) {
           <input className="border rounded p-1 w-full" value={icon} onChange={e => setIcon(e.target.value)} />
         ) : (
           f.icon
+        )}
+      </td>
+      <td className="p-3">
+        {editing ? (
+          <textarea className="border rounded p-1 w-full" value={description} onChange={e => setDescription(e.target.value)} rows={2} />
+        ) : (
+          <span className="block max-w-xs whitespace-pre-wrap break-words text-sm text-gray-700">{f.description || '—'}</span>
         )}
       </td>
       <td className="p-3">
@@ -60,6 +74,7 @@ export default function FeaturesAdmin() {
 
   const [name, setName] = useState('');
   const [icon, setIcon] = useState('');
+  const [description, setDescription] = useState('');
   const [saving, setSaving] = useState(false);
   const [rowBusyId, setRowBusyId] = useState(null);
 
@@ -85,8 +100,8 @@ export default function FeaturesAdmin() {
     e.preventDefault();
     setSaving(true);
     try {
-      await httpPost('/features', { name, icon });
-      setName(''); setIcon('');
+      await httpPost('/features', { name, description, icon }, { expectedStatus: 201 });
+      setName(''); setIcon(''); setDescription('');
       toast?.success(formatMessage({ id: 'admin.features.createSuccess', defaultMessage: 'Feature created successfully.' }));
       await load();
     } catch (e) {
@@ -100,7 +115,7 @@ export default function FeaturesAdmin() {
   const onSaveRow = async (feat) => {
     setRowBusyId(feat.id);
     try {
-      await httpPut(`/features/${feat.id}`, { name: feat.name, icon: feat.icon });
+      await httpPut(`/features/${feat.id}`, { name: feat.name, description: feat.description, icon: feat.icon }, { expectedStatus: 200 });
       toast?.success(formatMessage({ id: 'admin.features.updateSuccess', defaultMessage: 'Feature updated.' }));
       await load();
     } catch (e) {
@@ -146,6 +161,10 @@ export default function FeaturesAdmin() {
           <label className="text-sm">Icon (CSS class or emoji)</label>
           <input className="border rounded p-2" required value={icon} onChange={e => setIcon(e.target.value)} />
         </div>
+        <div className="grid gap-1">
+          <label className="text-sm">Description</label>
+          <textarea className="border rounded p-2" value={description} onChange={e => setDescription(e.target.value)} rows={3} placeholder="Optional description" />
+        </div>
         <div>
           <button className="px-4 py-2 rounded bg-gray-900 text-white hover:bg-black disabled:opacity-60" disabled={saving}>
             {saving ? 'Saving…' : 'Create'}
@@ -161,6 +180,7 @@ export default function FeaturesAdmin() {
               <th className="text-left p-3">ID</th>
               <th className="text-left p-3">Name</th>
               <th className="text-left p-3">Icon</th>
+              <th className="text-left p-3">Description</th>
               <th className="text-left p-3">Actions</th>
             </tr>
           </thead>
@@ -176,7 +196,7 @@ export default function FeaturesAdmin() {
             ))}
             {items.length === 0 && (
               <tr>
-                <td colSpan={4} className="p-4 text-center text-gray-500">No features.</td>
+                <td colSpan={5} className="p-4 text-center text-gray-500">No features.</td>
               </tr>
             )}
           </tbody>

--- a/frontend/src/pages/admin/ProductCreateAdmin.jsx
+++ b/frontend/src/pages/admin/ProductCreateAdmin.jsx
@@ -263,13 +263,19 @@ export default function ProductCreateAdmin() {
             {features.map((feature) => {
               const selected = form.featureIds.includes(feature.id);
               return (
-                <label key={feature.id} className="flex items-center gap-2 border rounded px-3 py-2 bg-white">
+                <label key={feature.id} className="flex items-start gap-3 border rounded px-3 py-2 bg-white">
                   <input
                     type="checkbox"
                     checked={selected}
                     onChange={() => toggleFeature(feature.id)}
                   />
-                  <span>{feature.name}</span>
+                  {feature.icon && <span className="text-lg leading-none">{feature.icon}</span>}
+                  <span className="flex-1">
+                    <span className="block text-sm font-medium text-gray-900">{feature.name}</span>
+                    {feature.description && (
+                      <span className="block text-xs text-gray-500">{feature.description}</span>
+                    )}
+                  </span>
                 </label>
               );
             })}

--- a/frontend/src/pages/admin/ProductEditAdmin.jsx
+++ b/frontend/src/pages/admin/ProductEditAdmin.jsx
@@ -214,7 +214,7 @@ function isValid(form) {
                     <button
                         key={f.id}
                         type="button"
-                        className={`px-3 py-1 rounded-lg border text-sm ${
+                        className={`px-3 py-2 rounded-lg border text-left text-sm ${
                         active ? "bg-emerald-600 text-white border-emerald-600" : "hover:bg-slate-50"
                         }`}
                         onClick={() => {
@@ -224,9 +224,18 @@ function isValid(form) {
                             return { ...prev, featureIds: Array.from(set) };
                         });
                         }}
-                        title={f.name}
                     >
-                        {f.name}
+                        <span className="flex items-start gap-2">
+                            {f.icon && <span className="text-base leading-none">{f.icon}</span>}
+                            <span className="flex-1">
+                                <span className="block font-medium">{f.name}</span>
+                                {f.description && (
+                                    <span className={`block text-xs ${active ? "text-emerald-50" : "text-slate-500"}`}>
+                                        {f.description}
+                                    </span>
+                                )}
+                            </span>
+                        </span>
                     </button>
                     );
                 })}


### PR DESCRIPTION
## Summary
- add description support to the feature admin table and forms
- validate create/update feature requests expect 201/200 responses
- surface feature descriptions in product create/edit feature selectors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce3414009483288032f79e4f9927d8