### PR TITLE
Add feature summaries to product response and frontend display

### DIFF
--- a/backend/src/main/java/com/miapp/reservashotel/dto/FeatureSummaryDTO.java
+++ b/backend/src/main/java/com/miapp/reservashotel/dto/FeatureSummaryDTO.java
@@ -1,0 +1,42 @@
+package com.miapp.reservashotel.dto;
+
+/** Lightweight feature representation for embedding in product responses. */
+public class FeatureSummaryDTO {
+
+    private Long id;
+    private String name;
+    private String icon;
+
+    public FeatureSummaryDTO() {
+    }
+
+    public FeatureSummaryDTO(Long id, String name, String icon) {
+        this.id = id;
+        this.name = name;
+        this.icon = icon;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+}

--- a/backend/src/main/java/com/miapp/reservashotel/dto/ProductResponseDTO.java
+++ b/backend/src/main/java/com/miapp/reservashotel/dto/ProductResponseDTO.java
@@ -17,6 +17,7 @@ public class ProductResponseDTO {
     private String cityName;
     private Set<Long> featureIds;
     private List<String> imageUrls;
+    private List<FeatureSummaryDTO> featureSummaries;
     private Double ratingAverage;
     private Long ratingCount;
 
@@ -27,7 +28,8 @@ public class ProductResponseDTO {
                               Long categoryId, String categoryName,
                               Long cityId, String cityName,
                               Set<Long> featureIds, List<String> imageUrls,
-                              Double ratingAverage, Long ratingCount) {
+                              Double ratingAverage, Long ratingCount,
+                              List<FeatureSummaryDTO> featureSummaries) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -41,6 +43,7 @@ public class ProductResponseDTO {
         this.imageUrls = imageUrls;
         this.ratingAverage = ratingAverage;
         this.ratingCount = ratingCount;
+        this.featureSummaries = featureSummaries;
     }
 
     // Getters and setters
@@ -79,4 +82,6 @@ public class ProductResponseDTO {
     public void setRatingAverage(Double ratingAverage) { this.ratingAverage = ratingAverage; }
     public Long getRatingCount() { return ratingCount; }
     public void setRatingCount(Long ratingCount) { this.ratingCount = ratingCount; }
+    public List<FeatureSummaryDTO> getFeatureSummaries() { return featureSummaries; }
+    public void setFeatureSummaries(List<FeatureSummaryDTO> featureSummaries) { this.featureSummaries = featureSummaries; }
 }

--- a/backend/src/main/java/com/miapp/reservashotel/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/miapp/reservashotel/service/impl/ProductServiceImpl.java
@@ -1,6 +1,7 @@
 package com.miapp.reservashotel.service.impl;
 
 import com.miapp.reservashotel.dto.ProductRequestDTO;
+import com.miapp.reservashotel.dto.FeatureSummaryDTO;
 import com.miapp.reservashotel.dto.ProductResponseDTO;
 import com.miapp.reservashotel.exception.ResourceConflictException;
 import com.miapp.reservashotel.exception.ResourceNotFoundException;
@@ -254,6 +255,15 @@ public class ProductServiceImpl implements ProductService {
             dto.setFeatureIds(featureIds);
         } catch (Throwable ignored) { /* DTO may not expose setter in some variants */ }
 
+        List<FeatureSummaryDTO> summaries = p.getFeatures() == null
+                ? Collections.emptyList()
+                : p.getFeatures().stream()
+                    .map(f -> new FeatureSummaryDTO(f.getId(), safeName(f), safeIcon(f)))
+                    .toList();
+        try {
+            dto.setFeatureSummaries(summaries);
+        } catch (Throwable ignored) { /* optional */ }
+
         // Ratings are optional on the entity
         try {
             dto.setRatingAverage(p.getRatingAverage());
@@ -266,5 +276,21 @@ public class ProductServiceImpl implements ProductService {
         } catch (Throwable ignored) { /* optional */ }
 
         return dto;
+    }
+
+    private String safeName(Feature feature) {
+        try {
+            return feature.getName();
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private String safeIcon(Feature feature) {
+        try {
+            return feature.getIcon();
+        } catch (Throwable ignored) {
+            return null;
+        }
     }
 }

--- a/backend/src/main/resources/static/openapi.yaml
+++ b/backend/src/main/resources/static/openapi.yaml
@@ -62,6 +62,14 @@ components:
         featureIds:
           type: array
           items: { type: integer, format: int64 }
+        featureSummaries:
+          type: array
+          items:
+            type: object
+            properties:
+              id: { type: integer, format: int64 }
+              name: { type: string }
+              icon: { type: string }
         imageUrl: { type: string }
 
     ProductSearchResponse:

--- a/frontend/src/pages/ProductDetail.jsx
+++ b/frontend/src/pages/ProductDetail.jsx
@@ -43,6 +43,15 @@ export default function ProductDetail() {
   const [selection, setSelection] = useState({ startDate: "", endDate: "" });
 
   const busyDates = useMemo(() => buildBusyDates(bookings), [bookings]);
+  const featureSummaries = useMemo(() => {
+    if (Array.isArray(product?.featureSummaries) && product.featureSummaries.length > 0) {
+      return product.featureSummaries;
+    }
+    if (Array.isArray(product?.features) && product.features.length > 0) {
+      return product.features;
+    }
+    return [];
+  }, [product]);
 
   const refreshProduct = useCallback(async () => {
     try {
@@ -147,8 +156,8 @@ export default function ProductDetail() {
       </section>
 
       {/* Features */}
-      {Array.isArray(product?.features) && product.features.length > 0 && (
-        <FeaturesBlock features={product.features} />
+      {featureSummaries.length > 0 && (
+        <FeaturesBlock features={featureSummaries} />
       )}
 
       {/* Availability (busy dates highlighted) with retry on error */}

--- a/frontend/src/services/products.js
+++ b/frontend/src/services/products.js
@@ -6,7 +6,12 @@ import Api from "./api.js";
 /** Fetch a single product by id. */
 export async function getProduct(id) {
   const { data } = await Api.get(`/products/${id}`);
-  return data;
+  const featureSummaries = Array.isArray(data?.featureSummaries)
+    ? data.featureSummaries
+    : Array.isArray(data?.features)
+    ? data.features
+    : [];
+  return { ...data, featureSummaries };
 }
 
 /** Fetch all categories. Accepts both paged and plain-array backends. */


### PR DESCRIPTION
## Summary
- add a lightweight `FeatureSummaryDTO` and expose it from `ProductResponseDTO`
- map product features to the new summaries list in `ProductServiceImpl`
- update OpenAPI docs and frontend product detail view to use the enriched features list

## Testing
- `./mvnw test` *(fails: wget could not fetch Maven distribution due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3427303c832884a67ac9bd4a54bb