### PR TITLE
Restrict admin endpoints to ADMIN role

### DIFF
--- a/backend/src/main/java/com/miapp/reservashotel/config/SecurityConfig.java
+++ b/backend/src/main/java/com/miapp/reservashotel/config/SecurityConfig.java
@@ -60,6 +60,33 @@ public class SecurityConfig {
                         "/swagger-ui/**",
                         "/swagger-ui.html"
                 ).permitAll()
+                // Admin routes and panel tools
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                // Admin-only mutations for catalog entities
+                .requestMatchers(HttpMethod.POST,
+                        "/api/categories/**",
+                        "/api/features/**",
+                        "/api/cities/**",
+                        "/api/products/**",
+                        "/api/policies/**",
+                        "/api/product-features/**"
+                ).hasRole("ADMIN")
+                .requestMatchers(HttpMethod.PUT,
+                        "/api/categories/**",
+                        "/api/features/**",
+                        "/api/cities/**",
+                        "/api/products/**",
+                        "/api/policies/**",
+                        "/api/product-features/**"
+                ).hasRole("ADMIN")
+                .requestMatchers(HttpMethod.DELETE,
+                        "/api/categories/**",
+                        "/api/features/**",
+                        "/api/cities/**",
+                        "/api/products/**",
+                        "/api/policies/**",
+                        "/api/product-features/**"
+                ).hasRole("ADMIN")
                 .requestMatchers(HttpMethod.GET, "/actuator/info").access((authz, context) -> {
                     if (actuatorInfoPublic) {
                         return new AuthorizationDecision(true);

--- a/backend/src/main/java/com/miapp/reservashotel/controller/AdminUserController.java
+++ b/backend/src/main/java/com/miapp/reservashotel/controller/AdminUserController.java
@@ -5,6 +5,7 @@ import com.miapp.reservashotel.dto.UserRolesResponseDTO;
 import com.miapp.reservashotel.service.AdminUserService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/api/admin/users")
+@PreAuthorize("hasRole('ADMIN')")
 public class AdminUserController {
 
     private final AdminUserService adminUserService;

--- a/backend/src/main/java/com/miapp/reservashotel/controller/CategoryController.java
+++ b/backend/src/main/java/com/miapp/reservashotel/controller/CategoryController.java
@@ -4,6 +4,7 @@ import com.miapp.reservashotel.dto.CategoryRequestDTO;
 import com.miapp.reservashotel.dto.CategoryResponseDTO;
 import com.miapp.reservashotel.service.CategoryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,18 +22,21 @@ public class CategoryController {
     public CategoryController(CategoryService categoryService) { this.categoryService = categoryService; }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<CategoryResponseDTO> createCategory(@RequestBody CategoryRequestDTO requestDTO) {
         CategoryResponseDTO responseDTO = categoryService.createCategory(requestDTO);
         return ResponseEntity.ok(responseDTO);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<CategoryResponseDTO> updateCategory(@PathVariable Long id, @RequestBody CategoryRequestDTO requestDTO) {
         CategoryResponseDTO responseDTO = categoryService.updateCategory(id, requestDTO);
         return ResponseEntity.ok(responseDTO);
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
         categoryService.deleteCategory(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/miapp/reservashotel/controller/CityController.java
+++ b/backend/src/main/java/com/miapp/reservashotel/controller/CityController.java
@@ -5,6 +5,7 @@ import com.miapp.reservashotel.model.City;
 import com.miapp.reservashotel.service.CityService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,12 +25,14 @@ public class CityController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<City> create(@RequestBody @Valid CityRequestDTO dto) {
         City created = cityService.createFromDTO(dto);
         return ResponseEntity.ok(created);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<City> update(@PathVariable Long id, @RequestBody @Valid CityRequestDTO dto) {
         City updated = cityService.updateFromDTO(id, dto);
         return ResponseEntity.ok(updated);
@@ -46,6 +49,7 @@ public class CityController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         cityService.deleteCity(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/miapp/reservashotel/controller/FeatureController.java
+++ b/backend/src/main/java/com/miapp/reservashotel/controller/FeatureController.java
@@ -5,6 +5,7 @@ import com.miapp.reservashotel.model.Feature;
 import com.miapp.reservashotel.service.FeatureService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -35,12 +36,14 @@ public class FeatureController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Feature> create(@RequestBody @Valid FeatureRequestDTO dto) {
         Feature created = featureService.createFromDTO(dto);
         return ResponseEntity.status(201).body(created);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Feature> update(@PathVariable Long id,
                                             @RequestBody @Valid FeatureRequestDTO dto) {
         Feature updated = featureService.updateFromDTO(id, dto);
@@ -48,6 +51,7 @@ public class FeatureController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         featureService.deleteFeature(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/miapp/reservashotel/controller/PolicyController.java
+++ b/backend/src/main/java/com/miapp/reservashotel/controller/PolicyController.java
@@ -5,6 +5,7 @@ import com.miapp.reservashotel.dto.PolicyResponseDTO;
 import com.miapp.reservashotel.service.PolicyService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,16 +26,19 @@ public class PolicyController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<PolicyResponseDTO> create(@Valid @RequestBody PolicyRequestDTO dto) {
         return ResponseEntity.ok(policyService.create(dto));
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<PolicyResponseDTO> update(@PathVariable Long id, @Valid @RequestBody PolicyRequestDTO dto) {
         return ResponseEntity.ok(policyService.update(id, dto));
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         policyService.delete(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/miapp/reservashotel/controller/ProductFeatureController.java
+++ b/backend/src/main/java/com/miapp/reservashotel/controller/ProductFeatureController.java
@@ -3,6 +3,7 @@ package com.miapp.reservashotel.controller;
 import com.miapp.reservashotel.model.ProductFeature;
 import com.miapp.reservashotel.service.ProductFeatureService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -32,6 +33,7 @@ public class ProductFeatureController {
     }
 
     @PostMapping("/assign")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> assign(@RequestParam Long productId,
                                         @RequestParam Long featureId) {
         // Service returns void; we return 204 as confirmation of success.
@@ -40,6 +42,7 @@ public class ProductFeatureController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         productFeatureService.deleteProductFeature(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/miapp/reservashotel/controller/SeedController.java
+++ b/backend/src/main/java/com/miapp/reservashotel/controller/SeedController.java
@@ -2,12 +2,14 @@ package com.miapp.reservashotel.controller;
 
 import com.miapp.reservashotel.seed.DataSeeder;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/admin/seed")
+@PreAuthorize("hasRole('ADMIN')")
 public class SeedController {
 
     private final DataSeeder seeder;

--- a/backend/src/test/java/com/miapp/reservashotel/AdminSecurityIntegrationTest.java
+++ b/backend/src/test/java/com/miapp/reservashotel/AdminSecurityIntegrationTest.java
@@ -1,0 +1,93 @@
+package com.miapp.reservashotel;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.miapp.reservashotel.dto.AdminRoleRequestDTO;
+import com.miapp.reservashotel.dto.CategoryRequestDTO;
+import com.miapp.reservashotel.dto.CategoryResponseDTO;
+import com.miapp.reservashotel.dto.UserRolesResponseDTO;
+import com.miapp.reservashotel.service.AdminUserService;
+import com.miapp.reservashotel.service.CategoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminSecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CategoryService categoryService;
+
+    @MockBean
+    private AdminUserService adminUserService;
+
+    private CategoryRequestDTO categoryRequest;
+
+    private AdminRoleRequestDTO adminRoleRequest;
+
+    @BeforeEach
+    void setUp() {
+        categoryRequest = new CategoryRequestDTO("Hotels", "Best hotels", "https://example.com/image.jpg");
+        adminRoleRequest = new AdminRoleRequestDTO("target@example.com");
+
+        when(categoryService.createCategory(any())).thenReturn(new CategoryResponseDTO(1L, "Hotels", "Best hotels", "https://example.com/image.jpg"));
+        when(adminUserService.grantAdmin(any())).thenReturn(new UserRolesResponseDTO(2L, "target@example.com", Set.of("ROLE_ADMIN")));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void shouldReturnForbiddenForCategoryCreationWithoutAdminRole() throws Exception {
+        mockMvc.perform(post("/api/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(categoryRequest)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldAllowCategoryCreationForAdminRole() throws Exception {
+        mockMvc.perform(post("/api/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(categoryRequest)))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void shouldReturnForbiddenForAdminPanelToolsWithoutAdminRole() throws Exception {
+        mockMvc.perform(post("/api/admin/users/grant-admin")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(adminRoleRequest)))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldAllowAdminPanelToolsForAdminRole() throws Exception {
+        mockMvc.perform(post("/api/admin/users/grant-admin")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(adminRoleRequest)))
+            .andExpect(status().isOk());
+    }
+}

--- a/backend/src/test/java/com/miapp/reservashotel/FeatureControllerIntegrationTest.java
+++ b/backend/src/test/java/com/miapp/reservashotel/FeatureControllerIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -39,6 +40,7 @@ class FeatureControllerIntegrationTest {
     }
 
     @Test
+    @WithMockUser(roles = "ADMIN")
     void shouldCreateFeature() throws Exception {
         mockMvc.perform(post("/api/features")
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## Summary
- require the ADMIN role for /api/admin/** routes and catalog mutations in the security filter chain
- add @PreAuthorize guards to admin controllers so only admins can perform create/update/delete operations
- cover admin vs non-admin access with new MockMvc integration tests

## Testing
- mvn test *(fails: missing parent POM due to offline Maven Central access)*

------
https://chatgpt.com/codex/tasks/task_e_68ce356eadfc8328b60787c73106915b